### PR TITLE
fix: create command handles missing config and creates symlinks for l…

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export { ConfigManager } from "./config/manager.js";
 // Export path calculation utilities
 export {
   calculateLocalPath,
+  calculateLocalPathWithSymlinks,
   formatPath,
   validatePath,
   validatePathSync,


### PR DESCRIPTION
…ocal folders

- Create command now creates initial .knowledge/config.yaml when missing
- Local folder docsets automatically get symlinks created in .knowledge/docsets/
- Export calculateLocalPathWithSymlinks from core package
- Add test for config creation and symlink functionality
- Fixes issues with CLI create command failing and local docsets not being visible