### PR TITLE
Fix local folder inconsistencies - require initialization and use symlinked paths

### DIFF
--- a/packages/cli/src/__tests__/create-command.test.ts
+++ b/packages/cli/src/__tests__/create-command.test.ts
@@ -136,7 +136,7 @@ describe("create command", () => {
     }
   });
 
-  it("creates config file when missing and creates symlinks for local folder", async () => {
+  it("creates config file when missing (symlinks created later via init)", async () => {
     // Remove the config file to test creation from scratch
     await fs.rm(join(testDir, ".knowledge"), { recursive: true, force: true });
 
@@ -176,13 +176,13 @@ describe("create command", () => {
       expect(config).toContain("name: Test Docs");
       expect(config).toContain("type: local_folder");
 
-      // Check symlinks were created
+      // Symlinks should NOT be created during create (only during init)
       const symlinkDir = join(testDir, ".knowledge", "docsets", "test-docs");
       const symlinkExists = await fs
         .access(symlinkDir)
         .then(() => true)
         .catch(() => false);
-      expect(symlinkExists).toBe(true);
+      expect(symlinkExists).toBe(false);
     } finally {
       process.cwd = originalCwd;
       console.log = originalLog;

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -69,28 +69,15 @@ export const createCommand = new Command("create")
       config.docsets.push(newDocset);
       await configManager.saveConfig(config, configPath);
 
-      // For local folders, create symlinks immediately
-      if (options.preset === "local-folder") {
-        console.log(chalk.gray("🔗 Creating symlinks for local folder..."));
-        const { calculateLocalPathWithSymlinks } = await import(
-          "@codemcp/knowledge-core"
-        );
-        try {
-          await calculateLocalPathWithSymlinks(newDocset, configPath);
-          console.log(chalk.gray("   ✅ Symlinks created successfully"));
-        } catch (error) {
-          console.log(
-            chalk.yellow(
-              `   ⚠️  Warning: Could not create symlinks: ${(error as Error).message}`,
-            ),
-          );
-        }
-      }
-
       console.log(
         chalk.green(`✅ Created docset '${options.id}' successfully`),
       );
       console.log(chalk.gray(`   Config saved to: ${configPath}`));
+      console.log(
+        chalk.yellow(
+          `\n💡 Next step: Initialize the docset with 'agentic-knowledge init ${options.id}'`,
+        ),
+      );
     } catch (error) {
       console.error(
         chalk.red("❌ Error creating docset:"),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,9 @@ export {
   ensureKnowledgeGitignoreSync,
 } from "./paths/calculator.js";
 
+// Export symlink utilities
+export { createSymlinks } from "./paths/symlinks.js";
+
 // Export template processing
 export {
   processTemplate,

--- a/test/utils/e2e-test-setup.ts
+++ b/test/utils/e2e-test-setup.ts
@@ -55,6 +55,29 @@ export async function createTestProject(
         const docFile = join(docsetPath, "README.md");
         await fs.writeFile(docFile, docset.content);
       }
+
+      // Initialize the docset (create symlinks and metadata for local folders)
+      // This simulates running 'agentic-knowledge init {docset-id}'
+      const symlinkDir = join(knowledgeDir, "docsets", docset.id);
+      await fs.mkdir(symlinkDir, { recursive: true });
+
+      // Create symlink to the actual source directory
+      const sourceName = docset.localPath.split("/").pop() || docset.id;
+      const symlinkPath = join(symlinkDir, sourceName);
+      await fs.symlink(docsetPath, symlinkPath, "dir");
+
+      // Create metadata file
+      const metadata = {
+        docset_id: docset.id,
+        docset_name: docset.name,
+        initialized_at: new Date().toISOString(),
+        total_files: 1,
+        sources_count: 1,
+      };
+      await fs.writeFile(
+        join(symlinkDir, ".agentic-metadata.json"),
+        JSON.stringify(metadata, null, 2),
+      );
     }
   }
 


### PR DESCRIPTION
This commit addresses several inconsistencies in how local documentation folders
were handled compared to git repositories:

Changes:
1. **Init command now supports local folders**
   - Creates symlinks in .knowledge/docsets/{id}/
   - Validates source paths exist
   - Creates .agentic-metadata.json for tracking
   - Counts files and stores metadata

2. **Server validates initialization for local folders**
   - Checks for .agentic-metadata.json before allowing search
   - Returns consistent error messages for uninitialized docsets
   - Both local folders and git repos now require explicit init

3. **Server returns symlinked paths for local folders**
   - Local folders now return .knowledge/docsets/{id}/ path
   - Agents no longer need to traverse up to project root
   - Consistent behavior between git repos and local folders

4. **Create command updated**
   - Removed automatic symlink creation for local folders
   - Added helpful message to run init command
   - Consistent flow: create -> init -> search

5. **Core package exports createSymlinks**
   - Exported from paths/symlinks.js for use in CLI

Result: Local folders now behave consistently with git repos - both
require initialization via 'agentic-knowledge init {docset_id}' before
they can be searched, and both return paths under .knowledge/docsets/.