### PR TITLE
feat: removes actual test search tool names from instructions

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -164,7 +164,7 @@ export class KnowledgeError extends Error {
 /**
  * Default instruction template
  */
-export const DEFAULT_TEMPLATE = `Use text search tools (grep, rg, ripgrep) to search for {{keywords}} in {{local_path}}. Try broader terms if needed. Skip: node_modules/, .git/, build/, dist/.`;
+export const DEFAULT_TEMPLATE = `Use available text search tools to search for {{keywords}} in {{local_path}}. Try broader terms if needed. Skip: node_modules/, .git/, build/, dist/.`;
 
 /**
  * Allowed template variables that can be used in instruction templates

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -186,7 +186,7 @@ Returns JSON object with:
 - generalized_search_terms: Broader terms for context
 - path: Local directory path to search in
 
-Use the path and search terms with your text search tools (grep, rg, ripgrep, find).`;
+Use the path and search terms with your available text search tools.`;
 
     return {
       tools: [


### PR DESCRIPTION
This grants more freedom to the agent and prevents from unsuccessful tries utilizing non-installed tools (like rg when it's not installed)