### PR TITLE
refactor!: rename to @codemcp/knowledge with ade-knowledge binary

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -67,6 +69,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.vibe/docs/requirements.md
+++ b/.vibe/docs/requirements.md
@@ -183,7 +183,7 @@ Complex requirements for unwanted behavior also include the If-Then keywords.
 
 - The system SHALL be distributable as NPM package
 - The system SHALL provide executable binary for MCP server
-- WHEN installed globally THEN the system SHALL be available as "ade-knowledge" command
+- WHEN installed globally THEN the system SHALL be available as "npx @codemcp/knowledge" command
 - The system SHALL follow semantic versioning for releases
 - The system SHALL include TypeScript type definitions for programmatic use
 
@@ -206,7 +206,7 @@ Complex requirements for unwanted behavior also include the If-Then keywords.
 
 **Acceptance Criteria:**
 
-- WHEN CLI command "ade-knowledge init {docset-id}" executed THEN the system SHALL clone configured Git repositories
+- WHEN CLI command "npx @codemcp/knowledge init {docset-id}" executed THEN the system SHALL clone configured Git repositories
 - WHEN Git repository requires authentication THEN the system SHALL use system Git credentials
 - WHEN Git repository URL is invalid THEN the system SHALL return clear error message
 - WHEN Git repository is unreachable THEN the system SHALL return network error with retry suggestion
@@ -234,10 +234,10 @@ Complex requirements for unwanted behavior also include the If-Then keywords.
 
 **Acceptance Criteria:**
 
-- WHEN "ade-knowledge init {docset-id}" executed AND docset has web_sources THEN the system SHALL download all configured sources
-- WHEN "ade-knowledge refresh" executed without docset-id THEN the system SHALL refresh all docsets with web_sources
-- WHEN "ade-knowledge refresh {docset-id}" executed THEN the system SHALL refresh only specified docset
-- WHEN "ade-knowledge status" executed THEN the system SHALL show last update time for each web source
+- WHEN "npx @codemcp/knowledge init {docset-id}" executed AND docset has web_sources THEN the system SHALL download all configured sources
+- WHEN "npx @codemcp/knowledge refresh" executed without docset-id THEN the system SHALL refresh all docsets with web_sources
+- WHEN "npx @codemcp/knowledge refresh {docset-id}" executed THEN the system SHALL refresh only specified docset
+- WHEN "npx @codemcp/knowledge status" executed THEN the system SHALL show last update time for each web source
 - WHEN network is unavailable during refresh THEN the system SHALL report error but continue with other sources
 - The system SHALL show progress indicators for long-running downloads
 

--- a/.vibe/docs/requirements.md
+++ b/.vibe/docs/requirements.md
@@ -183,7 +183,7 @@ Complex requirements for unwanted behavior also include the If-Then keywords.
 
 - The system SHALL be distributable as NPM package
 - The system SHALL provide executable binary for MCP server
-- WHEN installed globally THEN the system SHALL be available as "agentic-knowledge-mcp" command
+- WHEN installed globally THEN the system SHALL be available as "ade-knowledge" command
 - The system SHALL follow semantic versioning for releases
 - The system SHALL include TypeScript type definitions for programmatic use
 
@@ -206,7 +206,7 @@ Complex requirements for unwanted behavior also include the If-Then keywords.
 
 **Acceptance Criteria:**
 
-- WHEN CLI command "agentic-knowledge init {docset-id}" executed THEN the system SHALL clone configured Git repositories
+- WHEN CLI command "ade-knowledge init {docset-id}" executed THEN the system SHALL clone configured Git repositories
 - WHEN Git repository requires authentication THEN the system SHALL use system Git credentials
 - WHEN Git repository URL is invalid THEN the system SHALL return clear error message
 - WHEN Git repository is unreachable THEN the system SHALL return network error with retry suggestion
@@ -234,10 +234,10 @@ Complex requirements for unwanted behavior also include the If-Then keywords.
 
 **Acceptance Criteria:**
 
-- WHEN "agentic-knowledge init {docset-id}" executed AND docset has web_sources THEN the system SHALL download all configured sources
-- WHEN "agentic-knowledge refresh" executed without docset-id THEN the system SHALL refresh all docsets with web_sources
-- WHEN "agentic-knowledge refresh {docset-id}" executed THEN the system SHALL refresh only specified docset
-- WHEN "agentic-knowledge status" executed THEN the system SHALL show last update time for each web source
+- WHEN "ade-knowledge init {docset-id}" executed AND docset has web_sources THEN the system SHALL download all configured sources
+- WHEN "ade-knowledge refresh" executed without docset-id THEN the system SHALL refresh all docsets with web_sources
+- WHEN "ade-knowledge refresh {docset-id}" executed THEN the system SHALL refresh only specified docset
+- WHEN "ade-knowledge status" executed THEN the system SHALL show last update time for each web source
 - WHEN network is unavailable during refresh THEN the system SHALL report error but continue with other sources
 - The system SHALL show progress indicators for long-running downloads
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ Add to your coding agent config something along the lines of
 
 ```bash
 # For a Git repository
-npx agentic-knowledge-mcp create \
+npx @codemcp/knowledge create \
   --preset git-repo \
   --id react-docs \
   --name "React Documentation" \
   --url https://github.com/facebook/react.git
 
 # Initialize (downloads the docs)
-npx agentic-knowledge-mcp init react-docs
+npx @codemcp/knowledge init react-docs
 
 # The MCP server starts automatically when Claude Desktop launches
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -5,28 +5,32 @@ This guide shows you how to manually test the agentic knowledge MCP server to ve
 ## Quick Test with curl/manual MCP calls
 
 1. **Start the server in a project with configuration**:
+
 ```bash
 cd your-project-with-knowledge-config
-npx agentic-knowledge
+npx @codemcp/knowledge
 ```
 
 2. **Test tools/list request**:
+
 ```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | npx agentic-knowledge
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | npx @codemcp/knowledge
 ```
 
 Expected response: JSON with `search_docs` and `list_docsets` tools.
 
 3. **Test list_docsets**:
+
 ```bash
-echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_docsets","arguments":{}}}' | npx agentic-knowledge
+echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_docsets","arguments":{}}}' | npx @codemcp/knowledge
 ```
 
 Expected response: List of available docsets from your configuration.
 
 4. **Test search_docs**:
+
 ```bash
-echo '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"search_docs","arguments":{"docset_id":"your-docset-id","keywords":"search terms","generalized_keywords":"related terms"}}}' | npx agentic-knowledge
+echo '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"search_docs","arguments":{"docset_id":"your-docset-id","keywords":"search terms","generalized_keywords":"related terms"}}}' | npx @codemcp/knowledge
 ```
 
 Expected response: Intelligent search instructions based on your template.
@@ -53,13 +57,15 @@ This ensures LLMs understand how to properly use the search functionality.
 ## Performance Validation
 
 The tests validate:
+
 - ✅ Server creation: <1ms
-- ✅ E2E response time: <1ms (well under 10ms requirement)  
+- ✅ E2E response time: <1ms (well under 10ms requirement)
 - ✅ Memory usage: <1MB
 
 ## What the Tests Cover
 
 ### Unit Tests (84 + 11 = 95)
+
 - Configuration discovery and loading
 - YAML parsing and validation
 - Path calculation and resolution
@@ -68,6 +74,7 @@ The tests validate:
 - Server lifecycle and caching
 
 ### E2E Tests (12)
+
 - MCP protocol compliance
 - Real client-server communication
 - Tool schema validation
@@ -79,6 +86,7 @@ The tests validate:
 ## Expected Test Output
 
 All tests should pass:
+
 ```
 Test Files  1 passed (1)
      Tests  12 passed (12)
@@ -86,6 +94,7 @@ Test Files  1 passed (1)
 ```
 
 If any tests fail, check:
+
 1. All dependencies installed (`pnpm install`)
 2. Project built successfully (`pnpm build`)
 3. No configuration conflicts in test environment

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -18,7 +18,7 @@ Complete guide to using Agentic Knowledge for managing and searching documentati
 
 ```bash
 # Install in your project
-npm install agentic-knowledge
+npm install @codemcp/knowledge
 
 # Or use directly with npx (no installation needed)
 npx @codemcp/knowledge --help

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -56,7 +56,7 @@ Since the packages aren't published to npm yet, you can install them locally:
 
 4. **Verify installation:**
    ```bash
-   ade-knowledge --help
+   npx @codemcp/knowledge --help
    ```
 
 ## Docset Lifecycle
@@ -88,7 +88,7 @@ Update already-initialized docsets with the latest content from their sources.
 
 ## CLI Commands
 
-The `ade-knowledge` CLI provides commands to manage your documentation lifecycle. When you run `ade-knowledge` without arguments, it starts the MCP server. With arguments, it executes CLI commands.
+The `npx @codemcp/knowledge` CLI provides commands to manage your documentation lifecycle. When you run `npx @codemcp/knowledge-server` without arguments, it starts the MCP server. With arguments to `npx @codemcp/knowledge`, it executes CLI commands.
 
 ### `create` - Create New Docset Configuration
 
@@ -271,7 +271,7 @@ react-docs (React Documentation)
 api-docs (API Documentation)
    Not initialized | 1 source(s) configured
 
-   💡 Run: ade-knowledge init api-docs
+   💡 Run: npx @codemcp/knowledge init api-docs
 ```
 
 ### `refresh` - Update Documentation
@@ -583,7 +583,7 @@ npx @codemcp/knowledge status my-docset --verbose
 
 ### MCP Server
 
-When you run `ade-knowledge` without arguments, it starts an MCP server that exposes two tools:
+When you run `npx @codemcp/knowledge-server` without arguments, it starts an MCP server that exposes two tools:
 
 #### `search_docs` Tool
 
@@ -647,7 +647,7 @@ Found 2 available docset(s):
   "mcpServers": {
     "agentic-knowledge": {
       "command": "npx",
-      "args": ["-y", "agentic-knowledge"]
+      "args": ["-y", "@codemcp/knowledge-server"]
     }
   }
 }
@@ -664,7 +664,7 @@ If you have agentic-knowledge installed in a specific project:
   "mcpServers": {
     "agentic-knowledge": {
       "command": "npx",
-      "args": ["-y", "agentic-knowledge"],
+      "args": ["-y", "@codemcp/knowledge-server"],
       "cwd": "/absolute/path/to/your/project"
     }
   }
@@ -675,13 +675,14 @@ This runs the server in your project directory, making it use your project's `.k
 
 **Option 3: Global npm installation**
 
-If you installed globally with `npm install -g agentic-knowledge`:
+If you installed globally with `npm install -g @codemcp/knowledge-server`:
 
 ```json
 {
   "mcpServers": {
     "agentic-knowledge": {
-      "command": "agentic-knowledge"
+      "command": "npx",
+      "args": ["-y", "@codemcp/knowledge-server"]
     }
   }
 }
@@ -698,7 +699,7 @@ If you installed globally with `npm install -g agentic-knowledge`:
 For other MCP clients, use:
 
 - **Command**: `npx`
-- **Args**: `["-y", "agentic-knowledge"]`
+- **Args**: `["-y", "@codemcp/knowledge-server"]`
 - **Transport**: stdio
 
 The server will start automatically when the MCP client launches.
@@ -733,7 +734,7 @@ The AI assistant will:
 
 **Error**: "Docset 'X' is not initialized"
 
-**Solution**: Run `ade-knowledge init X`
+**Solution**: Run `npx @codemcp/knowledge init X`
 
 ### Git Clone Failures
 
@@ -748,7 +749,7 @@ The AI assistant will:
 
 ### Status Shows Old Data
 
-**Solution**: Run `ade-knowledge refresh <docset-id>` to update
+**Solution**: Run `npx @codemcp/knowledge refresh <docset-id>` to update
 
 ### Symlinks Not Working
 
@@ -758,14 +759,14 @@ The AI assistant will:
 
 - Verify the source paths exist
 - Check file permissions
-- Re-run `ade-knowledge create` with the local folder preset
+- Re-run `npx @codemcp/knowledge create` with the local folder preset
 
 ### Search Not Finding Results
 
 **Tips:**
 
 - Try broader keywords with `generalized_keywords`
-- Check the docset is initialized: `ade-knowledge status`
+- Check the docset is initialized: `npx @codemcp/knowledge status`
 - Verify the documentation actually contains the terms
 - Use verbose status to see which files are included
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -21,7 +21,7 @@ Complete guide to using Agentic Knowledge for managing and searching documentati
 npm install agentic-knowledge
 
 # Or use directly with npx (no installation needed)
-npx agentic-knowledge --help
+npx @codemcp/knowledge --help
 ```
 
 ### From Source
@@ -56,7 +56,7 @@ Since the packages aren't published to npm yet, you can install them locally:
 
 4. **Verify installation:**
    ```bash
-   agentic-knowledge --help
+   ade-knowledge --help
    ```
 
 ## Docset Lifecycle
@@ -88,7 +88,7 @@ Update already-initialized docsets with the latest content from their sources.
 
 ## CLI Commands
 
-The `agentic-knowledge-mcp` CLI provides commands to manage your documentation lifecycle. When you run `agentic-knowledge-mcp` without arguments, it starts the MCP server. With arguments, it executes CLI commands.
+The `ade-knowledge` CLI provides commands to manage your documentation lifecycle. When you run `ade-knowledge` without arguments, it starts the MCP server. With arguments, it executes CLI commands.
 
 ### `create` - Create New Docset Configuration
 
@@ -97,7 +97,7 @@ Create docset configurations quickly using presets. Alternatively, you can manua
 **Git Repository Preset:**
 
 ```bash
-npx agentic-knowledge create \
+npx @codemcp/knowledge create \
   --preset git-repo \
   --id mcp-sdk \
   --name "MCP TypeScript SDK" \
@@ -108,7 +108,7 @@ npx agentic-knowledge create \
 **Local Folder Preset:**
 
 ```bash
-npx agentic-knowledge create \
+npx @codemcp/knowledge create \
   --preset local-folder \
   --id my-docs \
   --name "My Documentation" \
@@ -136,19 +136,19 @@ Initialize a configured docset by downloading and preparing documentation. Use t
 
 ```bash
 # Initialize a specific docset
-npx agentic-knowledge init mcp-sdk
+npx @codemcp/knowledge init mcp-sdk
 
 # Force re-initialization (clears directory and re-extracts)
-npx agentic-knowledge init mcp-sdk --force
+npx @codemcp/knowledge init mcp-sdk --force
 
 # Discover and update path patterns in config
-npx agentic-knowledge init mcp-sdk --discover-paths
+npx @codemcp/knowledge init mcp-sdk --discover-paths
 
 # Both together (clear, re-extract, and update config)
-npx agentic-knowledge init mcp-sdk --force --discover-paths
+npx @codemcp/knowledge init mcp-sdk --force --discover-paths
 
 # Use custom config path
-npx agentic-knowledge init mcp-sdk --config /path/to/config.yaml
+npx @codemcp/knowledge init mcp-sdk --config /path/to/config.yaml
 ```
 
 **Options:**
@@ -214,7 +214,7 @@ sources:
 
 ```bash
 # Start without paths, discover what files exist
-npx agentic-knowledge init my-docset --discover-paths
+npx @codemcp/knowledge init my-docset --discover-paths
 ```
 
 This analyzes the extracted files and updates your config with optimal directory patterns instead of listing hundreds of individual files.
@@ -246,13 +246,13 @@ View the status of all docsets and their sources:
 
 ```bash
 # Basic status
-npx agentic-knowledge status
+npx @codemcp/knowledge status
 
 # Detailed status with source information
-npx agentic-knowledge status --verbose
+npx @codemcp/knowledge status --verbose
 
 # Use custom config
-npx agentic-knowledge status --config /path/to/config.yaml
+npx @codemcp/knowledge status --config /path/to/config.yaml
 ```
 
 **Example output:**
@@ -271,7 +271,7 @@ react-docs (React Documentation)
 api-docs (API Documentation)
    Not initialized | 1 source(s) configured
 
-   💡 Run: agentic-knowledge init api-docs
+   💡 Run: ade-knowledge init api-docs
 ```
 
 ### `refresh` - Update Documentation
@@ -280,16 +280,16 @@ Update already-initialized docsets with latest content. This is a **smart, incre
 
 ```bash
 # Refresh all docsets
-npx agentic-knowledge refresh
+npx @codemcp/knowledge refresh
 
 # Refresh specific docset
-npx agentic-knowledge refresh mcp-sdk
+npx @codemcp/knowledge refresh mcp-sdk
 
 # Force refresh (ignore throttle)
-npx agentic-knowledge refresh mcp-sdk --force
+npx @codemcp/knowledge refresh mcp-sdk --force
 
 # Use custom config
-npx agentic-knowledge refresh --config /path/to/config.yaml
+npx @codemcp/knowledge refresh --config /path/to/config.yaml
 ```
 
 **Smart refresh logic:**
@@ -380,7 +380,7 @@ docsets:
 2. **Auto-discovery**: Use `--discover-paths` flag during init to automatically detect optimal paths
 
    ```bash
-   npx agentic-knowledge init my-docset --discover-paths
+   npx @codemcp/knowledge init my-docset --discover-paths
    ```
 
    This analyzes extracted files and updates config with directory patterns instead of individual files.
@@ -456,14 +456,14 @@ docsets:
 
 ```bash
 # 1. Create config for local docs
-npx agentic-knowledge create \
+npx @codemcp/knowledge create \
   --preset local-folder \
   --id my-project \
   --name "My Project Docs" \
   --path ./docs
 
 # 2. Check status
-npx agentic-knowledge status
+npx @codemcp/knowledge status
 
 # 3. Configure Claude Desktop (see MCP Integration section)
 # The server runs automatically when Claude launches
@@ -475,7 +475,7 @@ No initialization needed - local folders use symlinks!
 
 ```bash
 # 1. Create docset for a Git repository
-npx agentic-knowledge create \
+npx @codemcp/knowledge create \
   --preset git-repo \
   --id react-docs \
   --name "React Documentation" \
@@ -483,32 +483,32 @@ npx agentic-knowledge create \
   --branch main
 
 # 2. Initialize the docset (downloads docs)
-npx agentic-knowledge init react-docs
+npx @codemcp/knowledge init react-docs
 
 # 3. Check status
-npx agentic-knowledge status
+npx @codemcp/knowledge status
 
 # 4. Configure Claude Desktop (see MCP Integration section)
 # The server runs automatically when Claude launches
 
 # Later: Update documentation
-npx agentic-knowledge refresh react-docs
+npx @codemcp/knowledge refresh react-docs
 ```
 
 ### Workflow 3: Multi-Repository Setup
 
 ```bash
 # Set up multiple docsets
-npx agentic-knowledge create --preset git-repo --id frontend-docs --name "Frontend Docs" --url https://github.com/company/frontend.git
-npx agentic-knowledge create --preset git-repo --id backend-docs --name "Backend Docs" --url https://github.com/company/backend.git
-npx agentic-knowledge create --preset local-folder --id internal-docs --name "Internal Docs" --path ./docs
+npx @codemcp/knowledge create --preset git-repo --id frontend-docs --name "Frontend Docs" --url https://github.com/company/frontend.git
+npx @codemcp/knowledge create --preset git-repo --id backend-docs --name "Backend Docs" --url https://github.com/company/backend.git
+npx @codemcp/knowledge create --preset local-folder --id internal-docs --name "Internal Docs" --path ./docs
 
 # Initialize git repos
-npx agentic-knowledge init frontend-docs
-npx agentic-knowledge init backend-docs
+npx @codemcp/knowledge init frontend-docs
+npx @codemcp/knowledge init backend-docs
 
 # Check all statuses
-npx agentic-knowledge status --verbose
+npx @codemcp/knowledge status --verbose
 
 # Configure Claude Desktop (see MCP Integration section)
 # The server runs automatically when Claude launches
@@ -520,7 +520,7 @@ When you're not sure which paths to extract from a large repository:
 
 ```bash
 # 1. Create docset without specifying paths
-npx agentic-knowledge create \
+npx @codemcp/knowledge create \
   --preset git-repo \
   --id large-repo \
   --name "Large Repository Docs" \
@@ -531,10 +531,10 @@ npx agentic-knowledge create \
 # - Use smart filtering to extract documentation
 # - Analyze the extracted files
 # - Update config with optimal directory patterns (e.g., "docs/", "examples/")
-npx agentic-knowledge init large-repo --discover-paths
+npx @codemcp/knowledge init large-repo --discover-paths
 
 # 3. Check what was discovered
-npx agentic-knowledge status large-repo --verbose
+npx @codemcp/knowledge status large-repo --verbose
 
 # 4. Review and adjust the auto-generated paths in .knowledge/config.yaml
 # The discovered paths will look like:
@@ -546,7 +546,7 @@ npx agentic-knowledge status large-repo --verbose
 
 # 5. If you want to adjust and re-init with different paths:
 # Edit .knowledge/config.yaml, then:
-npx agentic-knowledge init large-repo --force
+npx @codemcp/knowledge init large-repo --force
 ```
 
 ### Workflow 5: Managing Path Configuration Changes
@@ -567,7 +567,7 @@ When you need to change which paths are extracted from a git repository:
 
 # 2. Force re-initialization to apply new configuration
 # This completely clears the old content and re-extracts based on new paths
-npx agentic-knowledge init my-docset --force
+npx @codemcp/knowledge init my-docset --force
 
 # Output you'll see:
 # 🗑️  Clearing existing directory...
@@ -576,14 +576,14 @@ npx agentic-knowledge init my-docset --force
 #     ✅ Copied 75 files using smart filtering
 
 # 3. Verify the changes
-npx agentic-knowledge status my-docset --verbose
+npx @codemcp/knowledge status my-docset --verbose
 ```
 
 ## MCP Integration
 
 ### MCP Server
 
-When you run `agentic-knowledge-mcp` without arguments, it starts an MCP server that exposes two tools:
+When you run `ade-knowledge` without arguments, it starts an MCP server that exposes two tools:
 
 #### `search_docs` Tool
 
@@ -733,7 +733,7 @@ The AI assistant will:
 
 **Error**: "Docset 'X' is not initialized"
 
-**Solution**: Run `agentic-knowledge init X`
+**Solution**: Run `ade-knowledge init X`
 
 ### Git Clone Failures
 
@@ -748,7 +748,7 @@ The AI assistant will:
 
 ### Status Shows Old Data
 
-**Solution**: Run `agentic-knowledge refresh <docset-id>` to update
+**Solution**: Run `ade-knowledge refresh <docset-id>` to update
 
 ### Symlinks Not Working
 
@@ -758,14 +758,14 @@ The AI assistant will:
 
 - Verify the source paths exist
 - Check file permissions
-- Re-run `agentic-knowledge create` with the local folder preset
+- Re-run `ade-knowledge create` with the local folder preset
 
 ### Search Not Finding Results
 
 **Tips:**
 
 - Try broader keywords with `generalized_keywords`
-- Check the docset is initialized: `agentic-knowledge status`
+- Check the docset is initialized: `ade-knowledge status`
 - Verify the documentation actually contains the terms
 - Use verbose status to see which files are included
 
@@ -776,7 +776,7 @@ The AI assistant will:
 **Solution**: Use `init --force` to completely clear and re-extract:
 
 ```bash
-npx agentic-knowledge init my-docset --force
+npx @codemcp/knowledge init my-docset --force
 ```
 
 This ensures:
@@ -792,7 +792,7 @@ This ensures:
 **Solution**: Use `init --discover-paths` to auto-optimize:
 
 ```bash
-npx agentic-knowledge init my-docset --force --discover-paths
+npx @codemcp/knowledge init my-docset --force --discover-paths
 ```
 
 This will convert something like:
@@ -829,7 +829,7 @@ paths:
 
 ```bash
 # Your source files in ./docs/ will NOT be deleted
-npx agentic-knowledge init my-local-docs --force
+npx @codemcp/knowledge init my-local-docs --force
 ```
 
 Output shows:

--- a/package.json
+++ b/package.json
@@ -48,17 +48,14 @@
     "clean:build": "turbo run clean:build"
   },
   "dependencies": {
-    "@codemcp/knowledge-server": "workspace:*",
-    "@codemcp/knowledge-content-loader": "workspace:*",
-    "@codemcp/knowledge-core": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.19.1",
-    "@types/js-yaml": "4.0.9",
-    "chalk": "^5.3.0",
-    "commander": "^12.0.0",
-    "js-yaml": "4.1.0",
-    "ora": "^8.0.1"
+    "adm-zip": "0.5.16",
+    "commander": "^12.0.0"
   },
   "devDependencies": {
+    "@codemcp/knowledge-content-loader": "workspace:*",
+    "@codemcp/knowledge-core": "workspace:*",
+    "@codemcp/knowledge-server": "workspace:*",
     "@eslint/js": "^9.34.0",
     "@modelcontextprotocol/inspector": "0.16.8",
     "@tsconfig/node22": "22.0.2",
@@ -74,6 +71,7 @@
     "oxlint": "1.14.0",
     "prettier": "^3.6.2",
     "rimraf": "^6.0.1",
+    "tsup": "^8.0.0",
     "turbo": "^2.5.6",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -1,17 +1,20 @@
 {
-  "name": "agentic-knowledge-mcp",
+  "name": "@codemcp/knowledge",
   "version": "1.6.2",
   "description": "A Model Context Protocol server for agentic knowledge guidance with web-based documentation loading and intelligent search instructions",
   "type": "module",
   "main": "packages/cli/dist/index.js",
   "bin": {
-    "agentic-knowledge": "packages/cli/dist/index.js"
+    "ade-knowledge": "packages/cli/dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "engines": {
     "node": ">=20.0.0",
     "pnpm": ">=9.0.0"
   },
-  "packageManager": "pnpm@10.29.3",
+  "packageManager": "pnpm@10.32.1",
   "files": [
     "packages/*/dist/**/*",
     "packages/*/package.json",
@@ -27,7 +30,7 @@
     "build": "turbo run build",
     "pack:local": "node scripts/prepare-local.cjs",
     "inspector": "npx @modelcontextprotocol/inspector",
-    "dev": "turbo run dev --filter=@codemcp/knowledge-core --filter=@codemcp/knowledge",
+    "dev": "turbo run dev --filter=@codemcp/knowledge-core --filter=@codemcp/knowledge-server",
     "clean": "turbo run clean:build",
     "prepublishOnly": "npm run build",
     "lint-staged": "npx lint-staged",
@@ -45,7 +48,7 @@
     "clean:build": "turbo run clean:build"
   },
   "dependencies": {
-    "@codemcp/knowledge": "workspace:*",
+    "@codemcp/knowledge-server": "workspace:*",
     "@codemcp/knowledge-content-loader": "workspace:*",
     "@codemcp/knowledge-core": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.19.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
   "main": "dist/exports.js",
   "types": "dist/exports.d.ts",
   "bin": {
-    "agentic-knowledge": "./dist/index.js"
+    "ade-knowledge": "./dist/index.js"
   },
   "exports": {
     ".": {
@@ -32,7 +32,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@codemcp/knowledge": "workspace:*",
+    "@codemcp/knowledge-server": "workspace:*",
     "@codemcp/knowledge-content-loader": "workspace:*",
     "@codemcp/knowledge-core": "workspace:*",
     "chalk": "^5.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,9 +18,11 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsup",
+    "build:tsc": "tsc -p tsconfig.build.json",
     "build:watch": "tsc -p tsconfig.build.json --watch",
     "clean": "rimraf dist",
+    "clean:build": "rimraf dist",
     "dev": "tsc -p tsconfig.build.json --watch",
     "lint": "oxlint && eslint .",
     "lint:fix": "oxlint --fix && eslint . --fix",
@@ -32,18 +34,21 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.11.5",
+    "adm-zip": "0.5.16",
+    "commander": "^12.0.0"
+  },
+  "devDependencies": {
     "@codemcp/knowledge-server": "workspace:*",
     "@codemcp/knowledge-content-loader": "workspace:*",
     "@codemcp/knowledge-core": "workspace:*",
-    "chalk": "^5.3.0",
-    "commander": "^12.0.0",
-    "ora": "^8.0.1"
-  },
-  "devDependencies": {
     "@eslint/js": "^9.34.0",
     "@types/node": "^24.3.0",
+    "chalk": "^5.3.0",
     "eslint": "^9.34.0",
+    "ora": "^8.0.1",
     "rimraf": "^6.0.1",
+    "tsup": "^8.0.0",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   },
@@ -56,5 +61,6 @@
     "git"
   ],
   "author": "Oliver Jägle <github@beimir.net>",
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,5 @@
 /**
- * CLI implementation for agentic-knowledge web content management
+ * CLI implementation for @codemcp/knowledge web content management
  */
 
 import { Command } from "commander";
@@ -12,7 +12,7 @@ export function runCli() {
   const program = new Command();
 
   program
-    .name("ade-knowledge")
+    .name("npx @codemcp/knowledge")
     .description("Manage web content sources for agentic knowledge system")
     .version("0.1.0");
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -12,7 +12,7 @@ export function runCli() {
   const program = new Command();
 
   program
-    .name("agentic-knowledge")
+    .name("ade-knowledge")
     .description("Manage web content sources for agentic knowledge system")
     .version("0.1.0");
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -84,7 +84,7 @@ export const createCommand = new Command("create")
       console.log(chalk.gray(`   Config saved to: ${configPath}`));
       console.log(
         chalk.yellow(
-          `\n💡 Next step: Initialize the docset with 'agentic-knowledge init ${options.id}'`,
+          `\n💡 Next step: Initialize the docset with 'npx @codemcp/knowledge init ${options.id}'`,
         ),
       );
     } catch (error) {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -185,7 +185,9 @@ function displaySummary(statuses: DocsetStatus[]) {
         ),
       );
       console.log();
-      console.log(chalk.blue(`   💡 Run: agentic-knowledge init ${docset.id}`));
+      console.log(
+        chalk.blue(`   💡 Run: npx @codemcp/knowledge init ${docset.id}`),
+      );
       continue;
     }
 
@@ -242,7 +244,7 @@ function displayDetailedStatus(status: DocsetStatus) {
       }
       console.log(
         chalk.blue(
-          "\n   💡 Run 'agentic-knowledge init " +
+          "\n   💡 Run 'npx @codemcp/knowledge init " +
             docset.id +
             "' to initialize",
         ),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,33 +6,17 @@
  * Routes to MCP server (no args) or CLI (with args)
  */
 
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import { existsSync } from "node:fs";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { startServer } from "@codemcp/knowledge-server";
+import { runCli } from "./cli.js";
 
 async function main() {
   const args = process.argv.slice(2);
 
   if (args.length === 0) {
     // No arguments, start MCP server
-    const isLocal = existsSync(
-      join(__dirname, "../../mcp-server/dist/index.js"),
-    );
-    if (isLocal) {
-      const { startServer } = await import("../../mcp-server/dist/cli.js");
-      await startServer();
-    } else {
-      // Use string literal to avoid TypeScript resolution issues
-      const mcpServerModule = "@codemcp/knowledge-server";
-      const { startServer } = await import(mcpServerModule);
-      await startServer();
-    }
+    await startServer();
   } else {
     // Any arguments, run CLI
-    const { runCli } = await import("./cli.js");
     runCli();
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,7 +26,7 @@ async function main() {
       await startServer();
     } else {
       // Use string literal to avoid TypeScript resolution issues
-      const mcpServerModule = "@codemcp/knowledge";
+      const mcpServerModule = "@codemcp/knowledge-server";
       const { startServer } = await import(mcpServerModule);
       await startServer();
     }

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    exports: "src/exports.ts",
+  },
+  format: ["esm"],
+  dts: false,
+  clean: true,
+  bundle: true,
+  // External: CommonJS packages that use Node.js built-ins via require()
+  // These must be in the ROOT package.json dependencies (CLI sub-package is private)
+  // - commander: uses require('events'), require('child_process'), etc.
+  // - adm-zip: CommonJS with complex require() patterns
+  // - @modelcontextprotocol/sdk: shared MCP protocol dependency
+  external: ["commander", "@modelcontextprotocol/sdk", "adm-zip"],
+  // Bundle everything else (pure ESM packages + internal)
+  noExternal: [
+    "@codemcp/knowledge-core",
+    "@codemcp/knowledge-content-loader",
+    "@codemcp/knowledge-server",
+    "chalk",
+    "ora",
+  ],
+  target: "node20",
+  sourcemap: false,
+});

--- a/packages/content-loader/package.json
+++ b/packages/content-loader/package.json
@@ -53,5 +53,6 @@
     "metadata"
   ],
   "author": "Oliver Jägle <github@beimir.net>",
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,5 +49,6 @@
     "templates"
   ],
   "author": "Oliver Jägle <github@beimir.net>",
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,12 +1,15 @@
 {
-  "name": "@codemcp/knowledge",
+  "name": "@codemcp/knowledge-server",
   "version": "1.6.2",
-  "description": "MCP server implementation for agentic knowledge guidance system",
+  "description": "Lightweight MCP server for agentic knowledge guidance",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "@codemcp/knowledge": "dist/bin.js"
+    "ade-knowledge-server": "dist/bin.js"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "exports": {
     ".": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -21,9 +21,11 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsup",
+    "build:tsc": "tsc -p tsconfig.build.json",
     "build:watch": "tsc -p tsconfig.build.json --watch",
     "clean": "rimraf dist",
+    "clean:build": "rimraf dist",
     "dev": "tsc -p tsconfig.build.json --watch",
     "start": "node dist/bin.js",
     "lint": "oxlint && eslint .",
@@ -36,15 +38,17 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@codemcp/knowledge-content-loader": "workspace:*",
-    "@codemcp/knowledge-core": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.19.1"
+    "@modelcontextprotocol/sdk": "^1.19.1",
+    "adm-zip": "0.5.16"
   },
   "devDependencies": {
+    "@codemcp/knowledge-content-loader": "workspace:*",
+    "@codemcp/knowledge-core": "workspace:*",
     "@eslint/js": "^9.34.0",
     "@types/node": "^24.3.0",
     "eslint": "^9.34.0",
     "rimraf": "^6.0.1",
+    "tsup": "^8.0.0",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   },

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -166,17 +166,17 @@ To configure docsets and use this tool:
 **Option 1: Use CLI (recommended)**
 \`\`\`bash
 # Create a docset for a Git repository
-agentic-knowledge create \\
+npx @codemcp/knowledge create \\
   --preset git-repo \\
   --id my-docs \\
   --name "My Documentation" \\
   --url https://github.com/user/repo.git
 
 # Initialize it (downloads the docs)
-agentic-knowledge init my-docs
+npx @codemcp/knowledge init my-docs
 
 # Restart the MCP server
-agentic-knowledge
+npx @codemcp/knowledge-server
 \`\`\`
 
 **Option 2: Manual configuration**
@@ -362,8 +362,8 @@ ${config.docsets.map((d) => `• **${d.id}** (${d.name})`).join("\n")}`,
               "No configuration file found.\n\n" +
                 "To configure docsets:\n\n" +
                 "**Option 1: Use CLI (recommended)**\n" +
-                'agentic-knowledge create --preset git-repo --id my-docs --name "My Docs" --url <repo-url>\n' +
-                "agentic-knowledge init my-docs\n\n" +
+                'npx @codemcp/knowledge create --preset git-repo --id my-docs --name "My Docs" --url <repo-url>\n' +
+                "npx @codemcp/knowledge init my-docs\n\n" +
                 "**Option 2: Manual configuration**\n" +
                 "Create .knowledge/config.yaml in your project root.\n" +
                 "See the search_docs tool description for example configuration.",
@@ -424,8 +424,8 @@ ${config.docsets.map((d) => `• **${d.id}** (${d.name})`).join("\n")}`,
                     "To configure docsets:\n\n" +
                     "**Option 1: Use CLI (recommended)**\n" +
                     "```bash\n" +
-                    'agentic-knowledge create --preset git-repo --id my-docs --name "My Docs" --url <repo-url>\n' +
-                    "agentic-knowledge init my-docs\n" +
+                    'npx @codemcp/knowledge create --preset git-repo --id my-docs --name "My Docs" --url <repo-url>\n' +
+                    "npx @codemcp/knowledge init my-docs\n" +
                     "```\n\n" +
                     "**Option 2: Manual configuration**\n" +
                     "Create `.knowledge/config.yaml`:\n" +

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -44,7 +44,7 @@ const GENERALIZED_KEYWORDS_DESCRIPTION =
 export function createAgenticKnowledgeServer() {
   const server = new Server(
     {
-      name: "agentic-knowledge",
+      name: "knowledge",
       version: "0.1.0",
     },
     {

--- a/packages/mcp-server/tsup.config.ts
+++ b/packages/mcp-server/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    bin: "src/bin.ts",
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  dts: false,
+  clean: true,
+  bundle: true,
+  external: ["@modelcontextprotocol/sdk", "adm-zip"],
+  noExternal: ["@codemcp/knowledge-core", "@codemcp/knowledge-content-loader"],
+  target: "node20",
+  sourcemap: false,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,15 +7,15 @@ settings:
 importers:
   .:
     dependencies:
-      "@codemcp/knowledge":
-        specifier: workspace:*
-        version: link:packages/mcp-server
       "@codemcp/knowledge-content-loader":
         specifier: workspace:*
         version: link:packages/content-loader
       "@codemcp/knowledge-core":
         specifier: workspace:*
         version: link:packages/core
+      "@codemcp/knowledge-server":
+        specifier: workspace:*
+        version: link:packages/mcp-server
       "@modelcontextprotocol/sdk":
         specifier: ^1.19.1
         version: 1.19.1
@@ -92,15 +92,15 @@ importers:
 
   packages/cli:
     dependencies:
-      "@codemcp/knowledge":
-        specifier: workspace:*
-        version: link:../mcp-server
       "@codemcp/knowledge-content-loader":
         specifier: workspace:*
         version: link:../content-loader
       "@codemcp/knowledge-core":
         specifier: workspace:*
         version: link:../core
+      "@codemcp/knowledge-server":
+        specifier: workspace:*
+        version: link:../mcp-server
       chalk:
         specifier: ^5.3.0
         version: 5.6.0
@@ -774,7 +774,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   "@oxlint/linux-arm64-musl@1.14.0":
     resolution:
@@ -783,7 +782,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   "@oxlint/linux-x64-gnu@1.14.0":
     resolution:
@@ -792,7 +790,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   "@oxlint/linux-x64-musl@1.14.0":
     resolution:
@@ -801,7 +798,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   "@oxlint/win32-arm64@1.14.0":
     resolution:
@@ -1379,7 +1375,6 @@ packages:
       }
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   "@rollup/rollup-linux-arm-musleabihf@4.50.0":
     resolution:
@@ -1388,7 +1383,6 @@ packages:
       }
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   "@rollup/rollup-linux-arm64-gnu@4.50.0":
     resolution:
@@ -1397,7 +1391,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   "@rollup/rollup-linux-arm64-musl@4.50.0":
     resolution:
@@ -1406,7 +1399,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   "@rollup/rollup-linux-loongarch64-gnu@4.50.0":
     resolution:
@@ -1415,7 +1407,6 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   "@rollup/rollup-linux-ppc64-gnu@4.50.0":
     resolution:
@@ -1424,7 +1415,6 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   "@rollup/rollup-linux-riscv64-gnu@4.50.0":
     resolution:
@@ -1433,7 +1423,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   "@rollup/rollup-linux-riscv64-musl@4.50.0":
     resolution:
@@ -1442,7 +1431,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   "@rollup/rollup-linux-s390x-gnu@4.50.0":
     resolution:
@@ -1451,7 +1439,6 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   "@rollup/rollup-linux-x64-gnu@4.50.0":
     resolution:
@@ -1460,7 +1447,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   "@rollup/rollup-linux-x64-musl@4.50.0":
     resolution:
@@ -1469,7 +1455,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   "@rollup/rollup-openharmony-arm64@4.50.0":
     resolution:
@@ -1538,7 +1523,6 @@ packages:
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   "@swc/core-linux-arm64-musl@1.13.5":
     resolution:
@@ -1548,7 +1532,6 @@ packages:
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   "@swc/core-linux-x64-gnu@1.13.5":
     resolution:
@@ -1558,7 +1541,6 @@ packages:
     engines: { node: ">=10" }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   "@swc/core-linux-x64-musl@1.13.5":
     resolution:
@@ -1568,7 +1550,6 @@ packages:
     engines: { node: ">=10" }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   "@swc/core-win32-arm64-msvc@1.13.5":
     resolution:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,16 @@ settings:
 importers:
   .:
     dependencies:
+      "@modelcontextprotocol/sdk":
+        specifier: ^1.19.1
+        version: 1.19.1
+      adm-zip:
+        specifier: 0.5.16
+        version: 0.5.16
+      commander:
+        specifier: ^12.0.0
+        version: 12.1.0
+    devDependencies:
       "@codemcp/knowledge-content-loader":
         specifier: workspace:*
         version: link:packages/content-loader
@@ -16,25 +26,6 @@ importers:
       "@codemcp/knowledge-server":
         specifier: workspace:*
         version: link:packages/mcp-server
-      "@modelcontextprotocol/sdk":
-        specifier: ^1.19.1
-        version: 1.19.1
-      "@types/js-yaml":
-        specifier: 4.0.9
-        version: 4.0.9
-      chalk:
-        specifier: ^5.3.0
-        version: 5.6.0
-      commander:
-        specifier: ^12.0.0
-        version: 12.1.0
-      js-yaml:
-        specifier: 4.1.0
-        version: 4.1.0
-      ora:
-        specifier: ^8.0.1
-        version: 8.2.0
-    devDependencies:
       "@eslint/js":
         specifier: ^9.34.0
         version: 9.39.2
@@ -80,6 +71,9 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.13.5)(postcss@8.5.6)(typescript@5.9.2)(yaml@2.8.1)
       turbo:
         specifier: ^2.5.6
         version: 2.5.6
@@ -92,6 +86,16 @@ importers:
 
   packages/cli:
     dependencies:
+      "@modelcontextprotocol/sdk":
+        specifier: ^1.11.5
+        version: 1.19.1
+      adm-zip:
+        specifier: 0.5.16
+        version: 0.5.16
+      commander:
+        specifier: ^12.0.0
+        version: 12.1.0
+    devDependencies:
       "@codemcp/knowledge-content-loader":
         specifier: workspace:*
         version: link:../content-loader
@@ -101,28 +105,27 @@ importers:
       "@codemcp/knowledge-server":
         specifier: workspace:*
         version: link:../mcp-server
-      chalk:
-        specifier: ^5.3.0
-        version: 5.6.0
-      commander:
-        specifier: ^12.0.0
-        version: 12.1.0
-      ora:
-        specifier: ^8.0.1
-        version: 8.2.0
-    devDependencies:
       "@eslint/js":
         specifier: ^9.34.0
         version: 9.39.2
       "@types/node":
         specifier: ^24.3.0
         version: 24.3.0
+      chalk:
+        specifier: ^5.3.0
+        version: 5.6.0
       eslint:
         specifier: ^9.34.0
         version: 9.39.2
+      ora:
+        specifier: ^8.0.1
+        version: 8.2.0
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.13.5)(postcss@8.5.6)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -203,16 +206,19 @@ importers:
 
   packages/mcp-server:
     dependencies:
+      "@modelcontextprotocol/sdk":
+        specifier: ^1.19.1
+        version: 1.19.1
+      adm-zip:
+        specifier: 0.5.16
+        version: 0.5.16
+    devDependencies:
       "@codemcp/knowledge-content-loader":
         specifier: workspace:*
         version: link:../content-loader
       "@codemcp/knowledge-core":
         specifier: workspace:*
         version: link:../core
-      "@modelcontextprotocol/sdk":
-        specifier: ^1.19.1
-        version: 1.19.1
-    devDependencies:
       "@eslint/js":
         specifier: ^9.34.0
         version: 9.39.2
@@ -225,6 +231,9 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.13.5)(postcss@8.5.6)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -292,10 +301,28 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  "@esbuild/aix-ppc64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [aix]
+
   "@esbuild/android-arm64@0.25.9":
     resolution:
       {
         integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [android]
+
+  "@esbuild/android-arm64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -310,10 +337,28 @@ packages:
     cpu: [arm]
     os: [android]
 
+  "@esbuild/android-arm@0.27.3":
+    resolution:
+      {
+        integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [android]
+
   "@esbuild/android-x64@0.25.9":
     resolution:
       {
         integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [android]
+
+  "@esbuild/android-x64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -328,10 +373,28 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  "@esbuild/darwin-arm64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [darwin]
+
   "@esbuild/darwin-x64@0.25.9":
     resolution:
       {
         integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@esbuild/darwin-x64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -346,10 +409,28 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  "@esbuild/freebsd-arm64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [freebsd]
+
   "@esbuild/freebsd-x64@0.25.9":
     resolution:
       {
         integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@esbuild/freebsd-x64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -364,10 +445,28 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  "@esbuild/linux-arm64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [linux]
+
   "@esbuild/linux-arm@0.25.9":
     resolution:
       {
         integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [linux]
+
+  "@esbuild/linux-arm@0.27.3":
+    resolution:
+      {
+        integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==,
       }
     engines: { node: ">=18" }
     cpu: [arm]
@@ -382,10 +481,28 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  "@esbuild/linux-ia32@0.27.3":
+    resolution:
+      {
+        integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [linux]
+
   "@esbuild/linux-loong64@0.25.9":
     resolution:
       {
         integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [loong64]
+    os: [linux]
+
+  "@esbuild/linux-loong64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==,
       }
     engines: { node: ">=18" }
     cpu: [loong64]
@@ -400,10 +517,28 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  "@esbuild/linux-mips64el@0.27.3":
+    resolution:
+      {
+        integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [mips64el]
+    os: [linux]
+
   "@esbuild/linux-ppc64@0.25.9":
     resolution:
       {
         integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@esbuild/linux-ppc64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==,
       }
     engines: { node: ">=18" }
     cpu: [ppc64]
@@ -418,10 +553,28 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  "@esbuild/linux-riscv64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [riscv64]
+    os: [linux]
+
   "@esbuild/linux-s390x@0.25.9":
     resolution:
       {
         integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [s390x]
+    os: [linux]
+
+  "@esbuild/linux-s390x@0.27.3":
+    resolution:
+      {
+        integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==,
       }
     engines: { node: ">=18" }
     cpu: [s390x]
@@ -436,10 +589,28 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  "@esbuild/linux-x64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [linux]
+
   "@esbuild/netbsd-arm64@0.25.9":
     resolution:
       {
         integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [netbsd]
+
+  "@esbuild/netbsd-arm64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -454,10 +625,28 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  "@esbuild/netbsd-x64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [netbsd]
+
   "@esbuild/openbsd-arm64@0.25.9":
     resolution:
       {
         integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openbsd]
+
+  "@esbuild/openbsd-arm64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -472,10 +661,28 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  "@esbuild/openbsd-x64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [openbsd]
+
   "@esbuild/openharmony-arm64@0.25.9":
     resolution:
       {
         integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@esbuild/openharmony-arm64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -490,10 +697,28 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  "@esbuild/sunos-x64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [sunos]
+
   "@esbuild/win32-arm64@0.25.9":
     resolution:
       {
         integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@esbuild/win32-arm64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -508,10 +733,28 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  "@esbuild/win32-ia32@0.27.3":
+    resolution:
+      {
+        integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [win32]
+
   "@esbuild/win32-x64@0.25.9":
     resolution:
       {
         integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [win32]
+
+  "@esbuild/win32-x64@0.27.3":
+    resolution:
+      {
+        integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -1868,6 +2111,14 @@ packages:
     engines: { node: ">=0.4.0" }
     hasBin: true
 
+  acorn@8.16.0:
+    resolution:
+      {
+        integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==,
+      }
+    engines: { node: ">=0.4.0" }
+    hasBin: true
+
   adm-zip@0.5.16:
     resolution:
       {
@@ -1915,6 +2166,12 @@ packages:
         integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==,
       }
     engines: { node: ">=12" }
+
+  any-promise@1.3.0:
+    resolution:
+      {
+        integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==,
+      }
 
   arg@4.1.3:
     resolution:
@@ -1987,6 +2244,15 @@ packages:
       }
     engines: { node: ">=18" }
 
+  bundle-require@5.1.0:
+    resolution:
+      {
+        integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    peerDependencies:
+      esbuild: ">=0.18"
+
   bytes@3.0.0:
     resolution:
       {
@@ -2056,6 +2322,13 @@ packages:
         integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==,
       }
     engines: { node: ">= 16" }
+
+  chokidar@4.0.3:
+    resolution:
+      {
+        integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
+      }
+    engines: { node: ">= 14.16.0" }
 
   chownr@3.0.0:
     resolution:
@@ -2154,6 +2427,13 @@ packages:
       }
     engines: { node: ">=20" }
 
+  commander@4.1.1:
+    resolution:
+      {
+        integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==,
+      }
+    engines: { node: ">= 6" }
+
   concat-map@0.0.1:
     resolution:
       {
@@ -2167,6 +2447,19 @@ packages:
       }
     engines: { node: ">=18" }
     hasBin: true
+
+  confbox@0.1.8:
+    resolution:
+      {
+        integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==,
+      }
+
+  consola@3.4.2:
+    resolution:
+      {
+        integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
+      }
+    engines: { node: ^14.18.0 || >=16.10.0 }
 
   content-disposition@0.5.2:
     resolution:
@@ -2394,6 +2687,14 @@ packages:
     engines: { node: ">=18" }
     hasBin: true
 
+  esbuild@0.27.3:
+    resolution:
+      {
+        integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
   escalade@3.2.0:
     resolution:
       {
@@ -2613,6 +2914,12 @@ packages:
       }
     engines: { node: ">=10" }
 
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution:
+      {
+        integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==,
+      }
+
   flat-cache@4.0.1:
     resolution:
       {
@@ -2715,6 +3022,7 @@ packages:
       {
         integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==,
       }
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
@@ -2723,6 +3031,7 @@ packages:
         integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==,
       }
     engines: { node: 20 || >=22 }
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:
@@ -2975,6 +3284,13 @@ packages:
       }
     engines: { node: 20 || >=22 }
 
+  joycon@3.1.1:
+    resolution:
+      {
+        integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
+      }
+    engines: { node: ">=10" }
+
   js-tokens@4.0.0:
     resolution:
       {
@@ -3039,6 +3355,12 @@ packages:
       }
     engines: { node: ">=14" }
 
+  lines-and-columns@1.2.4:
+    resolution:
+      {
+        integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
+      }
+
   lint-staged@16.1.6:
     resolution:
       {
@@ -3053,6 +3375,13 @@ packages:
         integrity: sha512-0aeh5HHHgmq1KRdMMDHfhMWQmIT/m7nRDTlxlFqni2Sp0had9baqsjJRvDGdlvgd6NmPE0nPloOipiQJGFtTHQ==,
       }
     engines: { node: ">=20.0.0" }
+
+  load-tsconfig@0.2.5:
+    resolution:
+      {
+        integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   locate-path@6.0.0:
     resolution:
@@ -3243,10 +3572,22 @@ packages:
       }
     engines: { node: ">= 18" }
 
+  mlly@1.8.1:
+    resolution:
+      {
+        integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==,
+      }
+
   ms@2.1.3:
     resolution:
       {
         integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
+
+  mz@2.7.0:
+    resolution:
+      {
+        integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
       }
 
   nano-spawn@1.0.2:
@@ -3481,6 +3822,13 @@ packages:
     engines: { node: ">=0.10" }
     hasBin: true
 
+  pirates@4.0.7:
+    resolution:
+      {
+        integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==,
+      }
+    engines: { node: ">= 6" }
+
   pkce-challenge@4.1.0:
     resolution:
       {
@@ -3494,6 +3842,33 @@ packages:
         integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==,
       }
     engines: { node: ">=16.20.0" }
+
+  pkg-types@1.3.1:
+    resolution:
+      {
+        integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==,
+      }
+
+  postcss-load-config@6.0.1:
+    resolution:
+      {
+        integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==,
+      }
+    engines: { node: ">= 18" }
+    peerDependencies:
+      jiti: ">=1.21.0"
+      postcss: ">=8.0.9"
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss@8.5.6:
     resolution:
@@ -3629,6 +4004,13 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  readdirp@4.1.2:
+    resolution:
+      {
+        integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==,
+      }
+    engines: { node: ">= 14.18.0" }
+
   require-directory@2.1.1:
     resolution:
       {
@@ -3642,6 +4024,13 @@ packages:
         integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
       }
     engines: { node: ">=4" }
+
+  resolve-from@5.0.0:
+    resolution:
+      {
+        integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
+      }
+    engines: { node: ">=8" }
 
   restore-cursor@5.1.0:
     resolution:
@@ -3841,6 +4230,13 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  source-map@0.7.6:
+    resolution:
+      {
+        integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==,
+      }
+    engines: { node: ">= 12" }
+
   spawn-rx@5.1.2:
     resolution:
       {
@@ -3935,6 +4331,14 @@ packages:
         integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==,
       }
 
+  sucrase@3.35.1:
+    resolution:
+      {
+        integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==,
+      }
+    engines: { node: ">=16 || 14 >=14.17" }
+    hasBin: true
+
   supports-color@7.2.0:
     resolution:
       {
@@ -3968,6 +4372,19 @@ packages:
         integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==,
       }
     engines: { node: ">=18" }
+
+  thenify-all@1.6.0:
+    resolution:
+      {
+        integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==,
+      }
+    engines: { node: ">=0.8" }
+
+  thenify@3.3.1:
+    resolution:
+      {
+        integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
+      }
 
   tinybench@2.9.0:
     resolution:
@@ -4046,6 +4463,12 @@ packages:
     peerDependencies:
       typescript: ">=4.8.4"
 
+  ts-interface-checker@0.1.13:
+    resolution:
+      {
+        integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==,
+      }
+
   ts-node@10.9.2:
     resolution:
       {
@@ -4068,6 +4491,28 @@ packages:
       {
         integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
       }
+
+  tsup@8.5.1:
+    resolution:
+      {
+        integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+    peerDependencies:
+      "@microsoft/api-extractor": ^7.36.0
+      "@swc/core": ^1
+      postcss: ^8.4.12
+      typescript: ">=4.5.0"
+    peerDependenciesMeta:
+      "@microsoft/api-extractor":
+        optional: true
+      "@swc/core":
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   turbo-darwin-64@2.5.6:
     resolution:
@@ -4145,6 +4590,12 @@ packages:
       }
     engines: { node: ">=14.17" }
     hasBin: true
+
+  ufo@1.6.3:
+    resolution:
+      {
+        integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==,
+      }
 
   undici-types@7.10.0:
     resolution:
@@ -4457,79 +4908,157 @@ snapshots:
   "@esbuild/aix-ppc64@0.25.9":
     optional: true
 
+  "@esbuild/aix-ppc64@0.27.3":
+    optional: true
+
   "@esbuild/android-arm64@0.25.9":
+    optional: true
+
+  "@esbuild/android-arm64@0.27.3":
     optional: true
 
   "@esbuild/android-arm@0.25.9":
     optional: true
 
+  "@esbuild/android-arm@0.27.3":
+    optional: true
+
   "@esbuild/android-x64@0.25.9":
+    optional: true
+
+  "@esbuild/android-x64@0.27.3":
     optional: true
 
   "@esbuild/darwin-arm64@0.25.9":
     optional: true
 
+  "@esbuild/darwin-arm64@0.27.3":
+    optional: true
+
   "@esbuild/darwin-x64@0.25.9":
+    optional: true
+
+  "@esbuild/darwin-x64@0.27.3":
     optional: true
 
   "@esbuild/freebsd-arm64@0.25.9":
     optional: true
 
+  "@esbuild/freebsd-arm64@0.27.3":
+    optional: true
+
   "@esbuild/freebsd-x64@0.25.9":
+    optional: true
+
+  "@esbuild/freebsd-x64@0.27.3":
     optional: true
 
   "@esbuild/linux-arm64@0.25.9":
     optional: true
 
+  "@esbuild/linux-arm64@0.27.3":
+    optional: true
+
   "@esbuild/linux-arm@0.25.9":
+    optional: true
+
+  "@esbuild/linux-arm@0.27.3":
     optional: true
 
   "@esbuild/linux-ia32@0.25.9":
     optional: true
 
+  "@esbuild/linux-ia32@0.27.3":
+    optional: true
+
   "@esbuild/linux-loong64@0.25.9":
+    optional: true
+
+  "@esbuild/linux-loong64@0.27.3":
     optional: true
 
   "@esbuild/linux-mips64el@0.25.9":
     optional: true
 
+  "@esbuild/linux-mips64el@0.27.3":
+    optional: true
+
   "@esbuild/linux-ppc64@0.25.9":
+    optional: true
+
+  "@esbuild/linux-ppc64@0.27.3":
     optional: true
 
   "@esbuild/linux-riscv64@0.25.9":
     optional: true
 
+  "@esbuild/linux-riscv64@0.27.3":
+    optional: true
+
   "@esbuild/linux-s390x@0.25.9":
+    optional: true
+
+  "@esbuild/linux-s390x@0.27.3":
     optional: true
 
   "@esbuild/linux-x64@0.25.9":
     optional: true
 
+  "@esbuild/linux-x64@0.27.3":
+    optional: true
+
   "@esbuild/netbsd-arm64@0.25.9":
+    optional: true
+
+  "@esbuild/netbsd-arm64@0.27.3":
     optional: true
 
   "@esbuild/netbsd-x64@0.25.9":
     optional: true
 
+  "@esbuild/netbsd-x64@0.27.3":
+    optional: true
+
   "@esbuild/openbsd-arm64@0.25.9":
+    optional: true
+
+  "@esbuild/openbsd-arm64@0.27.3":
     optional: true
 
   "@esbuild/openbsd-x64@0.25.9":
     optional: true
 
+  "@esbuild/openbsd-x64@0.27.3":
+    optional: true
+
   "@esbuild/openharmony-arm64@0.25.9":
+    optional: true
+
+  "@esbuild/openharmony-arm64@0.27.3":
     optional: true
 
   "@esbuild/sunos-x64@0.25.9":
     optional: true
 
+  "@esbuild/sunos-x64@0.27.3":
+    optional: true
+
   "@esbuild/win32-arm64@0.25.9":
+    optional: true
+
+  "@esbuild/win32-arm64@0.27.3":
     optional: true
 
   "@esbuild/win32-ia32@0.25.9":
     optional: true
 
+  "@esbuild/win32-ia32@0.27.3":
+    optional: true
+
   "@esbuild/win32-x64@0.25.9":
+    optional: true
+
+  "@esbuild/win32-x64@0.27.3":
     optional: true
 
   "@eslint-community/eslint-utils@4.9.1(eslint@9.39.2)":
@@ -5402,6 +5931,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  acorn@8.16.0: {}
+
   adm-zip@0.5.16: {}
 
   ajv@6.12.6:
@@ -5424,6 +5955,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.1: {}
+
+  any-promise@1.3.0: {}
 
   arg@4.1.3: {}
 
@@ -5474,6 +6007,11 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
   bytes@3.0.0: {}
 
   bytes@3.1.2: {}
@@ -5508,6 +6046,10 @@ snapshots:
   chalk@5.6.0: {}
 
   check-error@2.1.1: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
 
   chownr@3.0.0: {}
 
@@ -5560,6 +6102,8 @@ snapshots:
 
   commander@14.0.0: {}
 
+  commander@4.1.1: {}
+
   concat-map@0.0.1: {}
 
   concurrently@9.2.1:
@@ -5570,6 +6114,10 @@ snapshots:
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   content-disposition@0.5.2: {}
 
@@ -5683,6 +6231,35 @@ snapshots:
       "@esbuild/win32-arm64": 0.25.9
       "@esbuild/win32-ia32": 0.25.9
       "@esbuild/win32-x64": 0.25.9
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      "@esbuild/aix-ppc64": 0.27.3
+      "@esbuild/android-arm": 0.27.3
+      "@esbuild/android-arm64": 0.27.3
+      "@esbuild/android-x64": 0.27.3
+      "@esbuild/darwin-arm64": 0.27.3
+      "@esbuild/darwin-x64": 0.27.3
+      "@esbuild/freebsd-arm64": 0.27.3
+      "@esbuild/freebsd-x64": 0.27.3
+      "@esbuild/linux-arm": 0.27.3
+      "@esbuild/linux-arm64": 0.27.3
+      "@esbuild/linux-ia32": 0.27.3
+      "@esbuild/linux-loong64": 0.27.3
+      "@esbuild/linux-mips64el": 0.27.3
+      "@esbuild/linux-ppc64": 0.27.3
+      "@esbuild/linux-riscv64": 0.27.3
+      "@esbuild/linux-s390x": 0.27.3
+      "@esbuild/linux-x64": 0.27.3
+      "@esbuild/netbsd-arm64": 0.27.3
+      "@esbuild/netbsd-x64": 0.27.3
+      "@esbuild/openbsd-arm64": 0.27.3
+      "@esbuild/openbsd-x64": 0.27.3
+      "@esbuild/openharmony-arm64": 0.27.3
+      "@esbuild/sunos-x64": 0.27.3
+      "@esbuild/win32-arm64": 0.27.3
+      "@esbuild/win32-ia32": 0.27.3
+      "@esbuild/win32-x64": 0.27.3
 
   escalade@3.2.0: {}
 
@@ -5850,6 +6427,12 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.18
+      mlly: 1.8.1
+      rollup: 4.50.0
 
   flat-cache@4.0.1:
     dependencies:
@@ -6036,6 +6619,8 @@ snapshots:
     dependencies:
       "@isaacs/cliui": 8.0.2
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -6065,6 +6650,8 @@ snapshots:
 
   lilconfig@3.1.3: {}
 
+  lines-and-columns@1.2.4: {}
+
   lint-staged@16.1.6:
     dependencies:
       chalk: 5.6.0
@@ -6088,6 +6675,8 @@ snapshots:
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
+
+  load-tsconfig@0.2.5: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -6183,7 +6772,20 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  mlly@1.8.1:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
   ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nano-spawn@1.0.2: {}
 
@@ -6304,9 +6906,24 @@ snapshots:
 
   pidtree@0.6.0: {}
 
+  pirates@4.0.7: {}
+
   pkce-challenge@4.1.0: {}
 
   pkce-challenge@5.0.0: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.1
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.1):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.6
+      yaml: 2.8.1
 
   postcss@8.5.6:
     dependencies:
@@ -6378,9 +6995,13 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  readdirp@4.1.2: {}
+
   require-directory@2.1.1: {}
 
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   restore-cursor@5.1.0:
     dependencies:
@@ -6546,6 +7167,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.7.6: {}
+
   spawn-rx@5.1.2:
     dependencies:
       debug: 4.4.1
@@ -6597,6 +7220,16 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  sucrase@3.35.1:
+    dependencies:
+      "@jridgewell/gen-mapping": 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -6620,6 +7253,14 @@ snapshots:
       "@istanbuljs/schema": 0.1.3
       glob: 10.4.5
       minimatch: 9.0.5
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   tinybench@2.9.0: {}
 
@@ -6653,6 +7294,8 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
+  ts-interface-checker@0.1.13: {}
+
   ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.3.0)(typescript@5.9.2):
     dependencies:
       "@cspotcode/source-map-support": 0.8.1
@@ -6674,6 +7317,35 @@ snapshots:
       "@swc/core": 1.13.5
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(@swc/core@1.13.5)(postcss@8.5.6)(typescript@5.9.2)(yaml@2.8.1):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.6)(yaml@2.8.1)
+      resolve-from: 5.0.0
+      rollup: 4.50.0
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      "@swc/core": 1.13.5
+      postcss: 8.5.6
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   turbo-darwin-64@2.5.6:
     optional: true
@@ -6713,6 +7385,8 @@ snapshots:
       mime-types: 3.0.1
 
   typescript@5.9.2: {}
+
+  ufo@1.6.3: {}
 
   undici-types@7.10.0: {}
 


### PR DESCRIPTION
## Summary

- Rename package to `@codemcp/knowledge` (CLI) and `@codemcp/knowledge-server` (MCP)
- Binary names: `ade-knowledge` and `ade-knowledge-server`
- Use tsup bundler for self-contained packages
- Mark internal packages as private
- CommonJS deps (commander, adm-zip) must be external due to require() of Node built-ins
- Update pnpm to 10.32.1

## Breaking Change

Package renamed from `agentic-knowledge-mcp` to `@codemcp/knowledge`. Users should update their MCP configuration:

```json
{
  "mcpServers": {
    "knowledge": {
      "command": "npx",
      "args": ["@codemcp/knowledge-server"]
    }
  }
}
```

## Part of ADE Naming Convention

This is part of harmonizing naming across all `@codemcp/*` packages for the Agentic Development Environment.