### PR TITLE
fix: publish only public packages in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,28 +135,9 @@ jobs:
       - name: Publish to npm
         if: steps.version.outputs.new_tag
         run: |
-          # Publish core package first as other packages depend on it
-          cd packages/core
-          pnpm publish --access public --no-git-checks
-          cd ../..
-
-          # Publish content-loader package
-          cd packages/content-loader
-          pnpm publish --access public --no-git-checks
-          cd ../..
-
-          # Publish MCP server as standalone package
-          cd packages/mcp-server
-          pnpm publish --access public --no-git-checks
-          cd ../..
-
-           # Convert workspace dependencies to actual versions for publishing
-           # NOTE: pnpm 10+ now handles this automatically during pack/publish
-           # Keeping this line for reference, but it's no longer needed with pnpm 10.29.3+
-           # NEW_VERSION=${{ steps.version.outputs.new_version }}
-           # find packages -name "package.json" -exec sed -i 's/"workspace:\*"/"^'$NEW_VERSION'"/g' {} \;
-
-           # Publish main package
-          pnpm publish --access public --no-git-checks
+          # Publish only public packages (those without "private": true)
+          # Using pnpm publish with --filter to exclude private packages
+          pnpm --filter '@codemcp/knowledge-server' publish --access public --no-git-checks
+          pnpm --filter '@codemcp/knowledge' publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Skip private packages (`@codemcp/knowledge-core`, `@codemcp/knowledge-cli`, `@codemcp/knowledge-content-loader`) during npm publish
- Use explicit `--filter` flags instead of attempting to publish all packages

## Problem
The release workflow was trying to publish private packages (those marked with `"private": true`), causing the npm publish step to fail with `EPRIVATE` error.

## Solution
Changed from `cd packages/X && pnpm publish` approach to `pnpm --filter '@codemcp/package-name' publish`, explicitly listing only the public packages to publish.